### PR TITLE
Xcode 15.2 compilation issue

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Select latest available Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0.0'
+          xcode-version: '15.2.0'
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Build Swift Debug Package

--- a/Sources/ManagedModels/ModelMacroDefinition.swift
+++ b/Sources/ManagedModels/ModelMacroDefinition.swift
@@ -63,7 +63,7 @@ public macro Transient() =
  * An internal helper macro. Don't use this.
  */
 @available(swift 5.9)
-@attached(accessor, names: named(init))
+@attached(accessor/*, names: named(init)*/)
 public macro _PersistedProperty() =
   #externalMacro(module: "ManagedModelMacros", type: "PersistedPropertyMacro")
 


### PR DESCRIPTION
As per issue #25, while compiling with Xcode 15.2 "Expansion of macro '_PersistedProperty()' produced an unexpected setter" error is generated. This pull request aims to fix the error by removing the `names: named(init)` part from `@attached(accessor, names: named(init))` macro declaration for  `_PersistedProperty`.

@helje5 please make sure that I am right and this `names` is not strictly necessary in the declaration, as my knowledge of Swift Macros is limited.