### PR TITLE
Optional Codable property fix

### DIFF
--- a/Sources/ManagedModels/SchemaCompatibility/NSAttributeDescription+Data.swift
+++ b/Sources/ManagedModels/SchemaCompatibility/NSAttributeDescription+Data.swift
@@ -32,8 +32,8 @@ extension CoreData.NSAttributeDescription: SchemaProperty {
       if let baseType = attributeType.swiftBaseType(isOptional: isOptional) {
         return baseType
       }
-      guard let attributeValueClassName else { return Any.self }
-      return NSClassFromString(attributeValueClassName) ?? Any.self
+        guard let attributeValueClassName else { return isOptional ? Any?.self : Any.self }
+        return NSClassFromString(attributeValueClassName) ?? (isOptional ? Any?.self : Any.self)
     }
     set {
       // Note: This needs to match up w/ PersistentModel+KVC.

--- a/Sources/ManagedModels/SchemaCompatibility/NSAttributeDescription+Data.swift
+++ b/Sources/ManagedModels/SchemaCompatibility/NSAttributeDescription+Data.swift
@@ -32,8 +32,8 @@ extension CoreData.NSAttributeDescription: SchemaProperty {
       if let baseType = attributeType.swiftBaseType(isOptional: isOptional) {
         return baseType
       }
-        guard let attributeValueClassName else { return isOptional ? Any?.self : Any.self }
-        return NSClassFromString(attributeValueClassName) ?? (isOptional ? Any?.self : Any.self)
+      guard let attributeValueClassName else { return isOptional ? Any?.self : Any.self }
+      return NSClassFromString(attributeValueClassName) ?? (isOptional ? Any?.self : Any.self)
     }
     set {
       // Note: This needs to match up w/ PersistentModel+KVC.

--- a/Tests/ManagedModelTests/CodablePropertiesTests.swift
+++ b/Tests/ManagedModelTests/CodablePropertiesTests.swift
@@ -69,4 +69,28 @@ final class CodablePropertiesTests: XCTestCase {
     XCTAssertNotNil(attribute.valueTransformerName)
     XCTAssertEqual(attribute.valueTransformerName, transformerName.rawValue)
   }
+  
+  func testOptionalCodablePropertyEntity() throws {
+      let entity = try XCTUnwrap(
+          container?.managedObjectModel.entitiesByName["StoredAccess"]
+      )
+      
+      // Creating the entity should have registered the transformer for the
+      // CodableBox.
+      let transformerName = try XCTUnwrap(
+        ValueTransformer.valueTransformerNames().first(where: {
+            $0.rawValue.range(of: "CodableTransformerGSqVOO17ManagedModelTests8")
+            != nil
+        })
+      )
+      let transformer = try XCTUnwrap(ValueTransformer(forName: transformerName))
+      _ = transformer // to clear unused-wraning
+      
+      let attribute = try XCTUnwrap(entity.attributesByName["optionalSip"])
+      XCTAssertEqual(attribute.name, "optionalSip")
+      XCTAssertTrue(attribute.valueType == Any?.self)
+      // Fixtures.CodablePropertiesSchema.AccessSIP?.self)
+      XCTAssertNotNil(attribute.valueTransformerName)
+      XCTAssertEqual(attribute.valueTransformerName, transformerName.rawValue)
+  }
 }

--- a/Tests/ManagedModelTests/Schemas/CodablePropertySchema.swift
+++ b/Tests/ManagedModelTests/Schemas/CodablePropertySchema.swift
@@ -20,6 +20,7 @@ extension Fixtures {
       var token   : String
       var expires : Date
       var sip     : AccessSIP
+      var optionalSip : AccessSIP?
     }
     
     struct AccessSIP: Codable {


### PR DESCRIPTION
This PR fixes a small issue with `isOptional` value of `NSAttributeDescriptor` which caused issues while saving entities with nil values for optional Codable properties, as described in issue #32.

This PR changes the return value of `valueType` getter to properly reflect `isOptional` for `Any` types when a base type and Objective-C class is not set. Additionally a test case was added to catch this issue during testing.